### PR TITLE
Store API key + improve readme + read files properly + fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Don't have an API key? Run `hyperdash signup` to get one!
 
 ### API key storage
 
-If you signed up with the CLI, the Hyperdash CLI will automatically install your API key in a hyperdash.json file in the home directory for you user.
+If you signed up through the CLI, then your API key is already installed in hyperdash.json file in the home directory of your user.
 
 You can alternatively override this API key with a hyperdash.json file in your local directory (so you can have different API keys for different projects) or with the HYPERDASH_API_KEY environment variable.
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,35 @@ Once you've imported our library, make sure your API key is available in the HYP
 That's it! Open the Hyperdash mobile app and you should see your logs start to stream in!
 
 Don't have an API key? Run `hyperdash signup` to get one!
+
+### API key storage
+
+If you signed up with the CLI, the Hyperdash CLI will automatically install your API key in a hyperdash.json file in the home directory for you user.
+
+You can alternatively override this API key with a hyperdash.json file in your local directory (so you can have different API keys for different projects) or with the HYPERDASH_API_KEY environment variable.
+
+Finally, the monitor function accepts an api_key_getter argument that if passed in will be called everytime we need to retrieve your API key. Example:
+
+```
+# test_script.py
+
+from hyperdash.sdk import monitor
+
+# This function can do anything you want, as long as it returns a Hyperdash API key as a string
+def get_api_key():
+  return "super_secret_api_key"
+
+@monitor("dogs vs. cats", api_key_getter=get_api_key)
+def train_dogs_vs_cats():
+  print("Epoch 1, accuracy: 50%")
+  time.sleep(2)
+  print("Epoch 2, accuracy: 75%")
+  time.sleep(2)
+  print("Epoch 3, accuracy: 100%")
+```
+
+Keep in mind that we will call your function on a regular basis while the job is running (currently about once every 5 minutes) so that we can support API key rotation for long-running jobs.
+
+### API Key Rotation
+
+The Hyperdash library will try and load up your API key about once every 5 minutes. Generally speaking this isn't something you need to think about, but in the rare case that you need to rotate an API key without stopping a long-running job, you can just change the HYPERDASH_API_KEY environment variable or hyperdash.json file and the SDK will automatically pickup the new key within a few minutes.

--- a/hyperdash/README.MD
+++ b/hyperdash/README.MD
@@ -8,6 +8,8 @@
 4) Run `pip install --upgrade pip`
 5) Run `pip install -r requirements_dev.txt` to install dependencies
 
+Alternatively if you're trying to test the CLI, or just want to use the CLI to test the SDK code, you can run `python setup.py develop` and the Hyperdash library will be installed locally so that you can test it. Once you're done developing, run `python setup.py develop --uninstall` to clean up.
+
 ## Release new version
 
 1) Install [setuptools](https://packaging.python.org/tutorials/installing-packages/)

--- a/hyperdash/constants.py
+++ b/hyperdash/constants.py
@@ -7,6 +7,7 @@ import six
 AUTH_KEY_NAME = "x-hyperdash-auth"
 WAMP_ENDPOINT = "/api/v1/sdk/wamp"
 WAMP_REALM = u"hyperdash.v1.sdk"
+CACHE_API_KEY_FOR_SECONDS = 300
 
 
 def get_base_url():

--- a/hyperdash/constants.py
+++ b/hyperdash/constants.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import six
 
@@ -17,3 +18,26 @@ def get_base_url():
 
 def get_wamp_url():
     return get_base_url() + WAMP_ENDPOINT
+
+
+def get_hyperdash_json_paths():
+    return [
+        path for
+        path in
+        [get_hyperdash_json_home_path(), get_hyperdash_json_local_path()]
+        if path
+    ]
+
+
+def get_hyperdash_json_home_path():
+    return os.path.join(os.path.expanduser("~"), "hyperdash.json")
+
+
+def get_hyperdash_json_local_path():
+    main = sys.modules["__main__"]
+    if not hasattr(main, "__file__"):
+        return json_paths
+
+    main_file_path = os.path.abspath(main.__file__)
+    root_folder = os.path.dirname(main_file_path)
+    return os.path.join(root_folder, "hyperdash.json")

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -181,6 +181,10 @@ class HyperDash:
                 yield self.cleanup(False)
                 raise
 
-        LoopingCall(event_loop).start(1)
-        self.server_manager_instance.put_buf(self.create_run_started_message())
+        # Create run_start message before starting the LoopingCall to make sure that the
+        # run_started message always precedes any log messages
+        self.server_manager_instance.put_buf(self.create_run_started_message())        
+        # now=False to give the ServerManager a chance to setup a connection before we try
+        # and send messages.
+        LoopingCall(event_loop).start(1, now=False)
         reactor.run()

--- a/hyperdash/server_manager.py
+++ b/hyperdash/server_manager.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import time
 
 from collections import deque
 
@@ -16,11 +17,14 @@ from autobahn.wamp.types import CallOptions
 from twisted.internet import reactor, threads
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from .constants import AUTH_KEY_NAME, get_wamp_url, WAMP_REALM
+from .constants import AUTH_KEY_NAME, get_wamp_url, WAMP_REALM, get_hyperdash_json_paths
 
 
 # Python 2/3 compatibility
 __metaclass__ = type
+
+
+CACHE_API_KEY_FOR_SECONDS = 300
 
 
 class Borg:
@@ -75,6 +79,7 @@ class ServerManager(Borg, Session):
     def tick(self):
         if self.unauthorized:
             returnValue(False)
+
         # TODO: Max messages per tick?
         while True:
             try:
@@ -120,6 +125,15 @@ class ServerManager(Borg, Session):
                 returnValue(False)
 
     def get_api_key(self):
+        cur_time = time.time()
+
+        # Use cached API key if available
+        if self.fetched_api_key_at and cur_time - self.fetched_api_key_at >= CACHE_API_KEY_FOR_SECONDS:
+            return self.api_key
+
+        # Set this now regardless of the outcome to make sure it runs
+        self.fetched_api_key_at = cur_time
+
         # If they provided a custom function, just use that
         if self.custom_api_key_getter:
             api_key = self.custom_api_key_getter()
@@ -140,31 +154,25 @@ class ServerManager(Borg, Session):
             self.log_error_once("Unable to detect API key in hyperdash.json or HYPERDASH_API_KEY environment variable")
 
         if from_file and from_env:
-            self.log_error_once("Found API key in hyperdash.json AND HYPERDASH_API_KEY environment variable. Please only use one.")
+            self.log_error_once("Found API key in hyperdash.json AND HYPERDASH_API_KEY environment variable. Hyperdash.json will take precedence.")
 
-        return from_file or from_env
+        self.api_key = from_file or from_env
+        return self.api_key
 
     def get_api_key_from_file(self):
-        main = sys.modules["__main__"]
-        if not hasattr(main, "__file__"):
-            return None
+        parsed = None
+        for path in get_hyperdash_json_paths():
+            try:
+                with open(path, "r") as f:
+                    try:
+                        parsed = json.load(f)
+                    except ValueError:
+                        self.log_error_once("hyperdash.json is not valid JSON")
+                        return None
+            except IOError:
+                continue
 
-        main_file_path = os.path.abspath(main.__file__)
-        root_folder = os.path.dirname(main_file_path)
-        hyperdash_file_path = os.path.join(root_folder, "hyperdash.json")
-
-        try:
-            with open(hyperdash_file_path, "r") as f:
-                try:
-                    parsed = json.load(f)
-                except ValueError:
-                    self.log_error_once("hyperdash.json is not valid JSON")
-                    return None
-        except IOError:
-            self.logger.debug("hyperdash.json not found")
-            return None
-
-        return parsed.get("api_key")
+        return parsed.get('api_key') if parsed else None
 
     def get_api_key_from_env(self):
         return os.environ.get("HYPERDASH_API_KEY")
@@ -188,6 +196,8 @@ class ServerManager(Borg, Session):
         self.custom_api_key_getter = custom_api_key_getter
         self.logged_errors = set()
         self.unauthorized = False
+        self.api_key = None
+        self.fetched_api_key_at = None
 
         self.application_runner = ApplicationRunner(
             url=get_wamp_url(),

--- a/hyperdash/server_manager.py
+++ b/hyperdash/server_manager.py
@@ -12,19 +12,19 @@ from collections import deque
 from autobahn.twisted.wamp import Session
 from autobahn.twisted.wamp import ApplicationRunner
 from autobahn.wamp.exception import ApplicationError
-from autobahn.wamp.types import CallOptions
 
-from twisted.internet import reactor, threads
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import returnValue
 
-from .constants import AUTH_KEY_NAME, get_wamp_url, WAMP_REALM, get_hyperdash_json_paths
+from .constants import AUTH_KEY_NAME
+from .constants import CACHE_API_KEY_FOR_SECONDS
+from .constants import get_hyperdash_json_paths
+from .constants import get_wamp_url
+from .constants import WAMP_REALM
 
 
 # Python 2/3 compatibility
 __metaclass__ = type
-
-
-CACHE_API_KEY_FOR_SECONDS = 300
 
 
 class Borg:
@@ -128,7 +128,7 @@ class ServerManager(Borg, Session):
         cur_time = time.time()
 
         # Use cached API key if available
-        if self.fetched_api_key_at and cur_time - self.fetched_api_key_at >= CACHE_API_KEY_FOR_SECONDS:
+        if self.fetched_api_key_at and cur_time - self.fetched_api_key_at < CACHE_API_KEY_FOR_SECONDS:
             return self.api_key
 
         # Set this now regardless of the outcome to make sure it runs

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -4,13 +4,14 @@ import os
 import time
 import json
 
-from six.moves.urllib.parse import urlencode
 from six.moves.urllib.request import urlopen
 from six.moves import input
 
-from .constants import get_base_url
-from hyperdash.constants import get_hyperdash_json_paths, get_hyperdash_json_home_path
+from hyperdash.constants import get_hyperdash_json_home_path
+from hyperdash.constants import get_hyperdash_json_paths
 from hyperdash.sdk import monitor
+
+from .constants import get_base_url
 
 
 def signup():
@@ -49,8 +50,8 @@ def signup():
         We stored your API key in {} 
         and we'll use that as the default for future jobs!
 
-        If you want to see Hyperdash in action, install our
-        mobile app and then run `hyperdash demo`
+        If you want to see Hyperdash in action, run `hyperdash demo`
+        and then install our mobile app to monitor your job in realtime!
     """.format(get_hyperdash_json_home_path())
     )
 
@@ -116,19 +117,19 @@ def write_hyperdash_json_file(hyperdash_json):
 
 
 def get_api_key_from_file():
-        parsed = None
-        for path in get_hyperdash_json_paths():
-            try:
-                with open(path, "r") as f:
-                    try:
-                        parsed = json.load(f)
-                    except ValueError:
-                        print("hyperdash.json is not valid JSON")
-                        return None
-            except IOError:
-                continue
+    parsed = None
+    for path in get_hyperdash_json_paths():
+        try:
+            with open(path, "r") as f:
+                try:
+                    parsed = json.load(f)
+                except ValueError:
+                    print("hyperdash.json is not valid JSON")
+                    return None
+        except IOError:
+            continue
 
-        return parsed.get('api_key') if parsed else None
+    return parsed.get('api_key') if parsed else None
 
 
 def get_api_key_from_env():

--- a/hyperdash_cli/constants.py
+++ b/hyperdash_cli/constants.py
@@ -6,5 +6,5 @@ import six
 def get_base_url():
     return six.text_type(os.environ.get(
         "HYPERDASH_SERVER",
-        "https://hyperdash.io",
+        "https://hyperdash.io/api/v1",
     ))

--- a/hyperdash_cli/constants.py
+++ b/hyperdash_cli/constants.py
@@ -4,7 +4,9 @@ import six
 
 
 def get_base_url():
-    return six.text_type(os.environ.get(
-        "HYPERDASH_SERVER",
-        "https://hyperdash.io/api/v1",
-    ))
+    return six.text_type(
+        "{}/api/v1".format(os.environ.get(
+            "HYPERDASH_SERVER",
+            "https://hyperdash.io",
+        ))
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.1.14"
+version = "0.1.15"
 
 setup(
     name='hyperdash',


### PR DESCRIPTION
1) Store API key in user's home directory after signup automatically
2) Check for API key in local directory/user's home directory
3) Only reload API keys once every 5 minutes
4) Document how API keys are stored + how to rotate API keys
5) Improve CLI messages
6) Rename test --> demo
7) Fix "error communicating with hyperdash servers" error appearing even when we successfully connect
8) Fix situation where logs in server_manager happened too early and blocked all other messages forever