### PR TITLE
Prevent network thread from continuing to run in the background

### DIFF
--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -186,7 +186,8 @@ class HyperDash:
             raise_exceptions=False,
             timeout_seconds=1,
         )
-        # Prevent the network thread from continuiing to run in the background 
+        # Prevent the network thread from continuing to run in the background
+        # even if SystemExit is caught        
         self.shutdown_network_channel.put(True)
 
     def print_log_file_location(self):

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -186,6 +186,8 @@ class HyperDash:
             raise_exceptions=False,
             timeout_seconds=1,
         )
+        # Prevent the network thread from continuiing to run in the background 
+        self.shutdown_network_channel.put(True)
 
     def print_log_file_location(self):
         if self.log_file_path:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.7.4"
+version = "0.7.5"
 
 setup(
     name='hyperdash',


### PR DESCRIPTION
Make sure the network thread definitely shuts down in the case of a sudden cleanup, even if SystemExit is caught