### PR TITLE
Make CLI work with progress bars + Reduce amount of server messages sent

### DIFF
--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -141,8 +141,9 @@ class HyperDash:
 
     def capture_all_io(self):
         self.capture_io_local()
-        self.capture_io_local_server()
+        self.capture_io_server()
 
+    # Capture all IO for terminal/log file since we last checked
     def capture_io_local(self):
         self.out_buf.acquire()
         out = self.out_buf.getvalue()
@@ -160,7 +161,8 @@ class HyperDash:
         self.err_buf_offset += len_err
         self.err_buf.release()
 
-    def capture_io_local_server(self):
+    # Capture all IO for the ServerManager since we last checked
+    def capture_io_server(self):
         self.out_buf.acquire()
         out = self.out_buf.getvalue()
         len_out = len(out) - self.server_out_buf_offset

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -55,7 +55,7 @@ class HyperDash:
             5) std_streams: Tuple in the form of (StdOut, StdErr)
         """
         self.job_name = job_name
-        self.code_runner = code_runner    
+        self.code_runner = code_runner
         self.server_manager = server_manager
         self.out_buf, self.err_buf = io_bufs
         self.std_out, self.std_err = std_streams
@@ -67,13 +67,17 @@ class HyperDash:
         self.out_buf_offset = 0
         self.err_buf_offset = 0
 
+        self.server_out_buf_offset = 0
+        self.server_err_buf_offset = 0
+
         # Create a UUID to uniquely identify this run from the SDK's point of view
         self.current_sdk_run_uuid = str(uuid.uuid4())
 
         # Create run_start message before doing any other setup work to make sure that the
         # run_started message always precedes any other messages
         self.server_manager.put_buf(
-            create_run_started_message(self.current_sdk_run_uuid, self.job_name),
+            create_run_started_message(
+                self.current_sdk_run_uuid, self.job_name),
         )
 
         def on_stdout_flush():
@@ -92,11 +96,12 @@ class HyperDash:
         self.logger = logging.getLogger("hyperdash.{}".format(__name__))
         self.log_file, self.log_file_path = self.open_log_file()
         if not self.log_file:
-            self.logger.error("Could not create logs file. Logs will not be stored locally.")
+            self.logger.error(
+                "Could not create logs file. Logs will not be stored locally.")
 
     def open_log_file(self):
         log_folder = get_hyperdash_logs_home_path()
-        
+
         # Make sure logs directory exists (/logs)
         if not os.path.exists(log_folder):
             try:
@@ -129,28 +134,53 @@ class HyperDash:
         self.out_buf.acquire()
         out = self.out_buf.getvalue()
         len_out = len(out) - self.out_buf_offset
-        self.print_out(out[self.out_buf_offset:]) if len_out != 0 else None
+        if len_out != 0:
+            self.print_out(out[self.out_buf_offset:])
         self.out_buf_offset += len_out
         self.out_buf.release()
 
         self.err_buf.acquire()
         err = self.err_buf.getvalue()
         len_err = len(err) - self.err_buf_offset
-        self.print_err(err[self.err_buf_offset:]) if len_err != 0 else None
+        if len_err != 0:
+            self.print_err(err[self.err_buf_offset:])
         self.err_buf_offset += len_err
+        self.err_buf.release()
+
+    def capture_io_server(self):
+        self.out_buf.acquire()
+        out = self.out_buf.getvalue()
+        len_out = len(out) - self.server_out_buf_offset
+        if len_out != 0:
+            self.print_server_out(out[self.server_out_buf_offset:])
+        self.server_out_buf_offset += len_out
+        self.out_buf.release()
+
+        self.err_buf.acquire()
+        err = self.err_buf.getvalue()
+        len_err = len(err) - self.server_err_buf_offset
+        if len_err != 0:
+            self.print_server_err(err[self.server_err_buf_offset:])
+        self.server_err_buf_offset += len_err
         self.err_buf.release()
 
     def print_out(self, s):
         message = create_log_message(self.current_sdk_run_uuid, INFO_LEVEL, s)
-        self.server_manager.put_buf(message)
         self.std_out.write(s)
         self.write_to_log_file(s)
 
     def print_err(self, s):
         message = create_log_message(self.current_sdk_run_uuid, ERROR_LEVEL, s)
-        self.server_manager.put_buf(message)
         self.std_err.write(s)
         self.write_to_log_file(s)
+
+    def print_server_out(self, s):
+        message = create_log_message(self.current_sdk_run_uuid, INFO_LEVEL, s)
+        self.server_manager.put_buf(message)
+
+    def print_server_err(self, s):
+        message = create_log_message(self.current_sdk_run_uuid, ERROR_LEVEL, s)
+        self.server_manager.put_buf(message)
 
     def write_to_log_file(self, s):
         if self.log_file:
@@ -182,7 +212,8 @@ class HyperDash:
         # canceled by the user, but don't wait for all messages to
         # be flushed to server so we don't hang the user's terminal.
         self.server_manager.send_message(
-            create_run_ended_message(self.current_sdk_run_uuid, "user_canceled"),
+            create_run_ended_message(
+                self.current_sdk_run_uuid, "user_canceled"),
             raise_exceptions=False,
             timeout_seconds=1,
         )
@@ -247,9 +278,9 @@ class HyperDash:
 
         # Daemonize them so they don't impede shutdown if the user
         # keyboard interrupts
-        code_thread.daemon=True
-        network_thread.daemon=True
-      
+        code_thread.daemon = True
+        network_thread.daemon = True
+
         network_thread.start()
         code_thread.start()
 
@@ -257,18 +288,21 @@ class HyperDash:
         while True:
             try:
                 self.capture_io()
+                self.capture_io_server()
                 exited_cleanly, is_done = self.code_runner.is_done()
                 if is_done:
                     self.programmatic_exit = True
                     if exited_cleanly:
                         self.cleanup("success")
                         # Block until network loop says its done
-                        self.shutdown_main_channel.get(block=True, timeout=None)
+                        self.shutdown_main_channel.get(
+                            block=True, timeout=None)
                         return self.code_runner.get_return_val()
                     else:
                         self.cleanup("failure")
                         # Block until network loop says its done
-                        self.shutdown_main_channel.get(block=True, timeout=None)
+                        self.shutdown_main_channel.get(
+                            block=True, timeout=None)
                         raise self.code_runner.get_exception()
 
                 time.sleep(1)

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -73,9 +73,9 @@ class HyperDash:
         # want terminal/logs to update extremely quickly, but a small delay in
         # sending data to the server is acceptable so that more data can be batched
         # together. I.E if the user's code flushes 1000 times per second, we want
-        # to capture that in realtime, but only want to send one message to the
-        # server with the cumulative output of those 1000 flushes for the one second
-        # period.
+        # to capture that in realtime locally, but only want to send one message to
+        # the server with the cumulative output of those 1000 flushes for the one
+        # second period.
         self.server_out_buf_offset = 0
         self.server_err_buf_offset = 0
 

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -20,7 +20,6 @@ from .sdk_message import create_run_started_message
 from .sdk_message import create_run_ended_message
 from .sdk_message import create_log_message
 
-counter = 0
 # Python 2/3 compatibility
 __metaclass__ = type
 
@@ -304,9 +303,6 @@ class HyperDash:
                         # Block until network loop says its done
                         self.shutdown_main_channel.get(
                             block=True, timeout=None)
-                        global counter
-                        print("lmao")
-                        print(counter)
                         return self.code_runner.get_return_val()
                     else:
                         self.cleanup("failure")

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -62,10 +62,20 @@ class HyperDash:
         self.shutdown_network_channel = Queue()
         self.shutdown_main_channel = Queue()
 
-        # Used to keep track of the current position in the IO buffers
+        # Used to keep track of the current position in the IO buffers for data
+        # that has been sent to STDOUT/STDERR and the logfile
         self.out_buf_offset = 0
         self.err_buf_offset = 0
 
+        # Used to keep track of the current position in the IO buffers for data
+        # that has been sent to the ServerManager. We separate the local/server
+        # offsets because in the case of the user's code frequently flushing, we
+        # want terminal/logs to update extremely quickly, but a small delay in
+        # sending data to the server is acceptable so that more data can be batched
+        # together. I.E if the user's code flushes 1000 times per second, we want
+        # to capture that in realtime, but only want to send one message to the
+        # server with the cumulative output of those 1000 flushes for the one second
+        # period.
         self.server_out_buf_offset = 0
         self.server_err_buf_offset = 0
 

--- a/hyperdash/hyper_dash.py
+++ b/hyperdash/hyper_dash.py
@@ -134,8 +134,6 @@ class HyperDash:
         self.capture_io_local_server()
 
     def capture_io_local(self):
-        global counter
-        counter += 1
         self.out_buf.acquire()
         out = self.out_buf.getvalue()
         len_out = len(out) - self.out_buf_offset

--- a/hyperdash/io_buffer.py
+++ b/hyperdash/io_buffer.py
@@ -3,6 +3,7 @@ from threading import RLock
 
 from six import PY2
 
+
 def noop():
     pass
 
@@ -34,7 +35,7 @@ class IOBuffer:
 
     def set_on_flush(self, on_flush):
         self.on_flush = on_flush
-    
+
     def acquire(self):
         self.lock.acquire()
 

--- a/hyperdash/server_manager.py
+++ b/hyperdash/server_manager.py
@@ -24,6 +24,7 @@ from .sdk_message import create_heartbeat_message
 # Python 2/3 compatibility
 __metaclass__ = type
 
+counter = 0
 
 class ServerManagerBase():
     # TODO: Check type
@@ -121,6 +122,7 @@ class ServerManagerBase():
 class ServerManagerHTTP(ServerManagerBase):
 
     def tick(self, sdk_run_uuid):
+        global counter
         if self.unauthorized:
             returnValue(False)
 
@@ -152,6 +154,7 @@ class ServerManagerHTTP(ServerManagerBase):
             sent_successfully = False
             try:
                 res = self.send_message(message)
+                counter = counter+1
                 if res.status_code != 200:
                     # TODO: Server should return better error message
                     err_code = res.json()["code"]
@@ -165,7 +168,7 @@ class ServerManagerHTTP(ServerManagerBase):
                     "Unable to send message due to connection issues: {}".format(e),
                 )
             except Exception as e:
-                self.logger.debug(format_exc())
+                self.logger.info(format_exc())
                 self.log_error_once("Unable to communicate with Hyperdash servers")
 
             if sent_successfully is not True:
@@ -189,6 +192,7 @@ class ServerManagerHTTP(ServerManagerBase):
 
     def cleanup(self, sdk_run_uuid):
         # Try and flush any remaining messages
+        self.logger.info(counter)
         return self.tick(sdk_run_uuid)
 
     def __init__(self, custom_api_key_getter):

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -220,9 +220,8 @@ def run(args):
         # allows us read the pipe as fast as possible.
         #
         # We yield everytime we encounter whitespace instead
-        # of on every byte because if we did with for every
-        # byte it would break the UTF-8 decoding of multi-byte
-        # characters.
+        # of on every byte because yielding every byte individually
+        # would break the UTF-8 decoding of multi-byte characters.
         #
         # Before this we were using readline() which works in most
         # cases, but breaks for scripts that use loading bars

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -254,11 +254,7 @@ def run(args):
         # stdout/stderr respectively (which have been redirected by
         # the monitor decorator)
         def stdout_loop():
-            # for data in generate_tokens(p.stdout):
-            while True:
-                data = p.stdout.read(1)
-                if not data:
-                    return
+            for data in generate_tokens(p.stdout):
                 # In PY2 data is str, in PY3 its bytes
                 if PY2:
                     sys.stdout.write(data)

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -56,7 +56,7 @@ def signup(args=None):
         If you want to see Hyperdash in action, run `hyperdash demo`
         and then install our mobile app to monitor your job in realtime.
     """.format(get_hyperdash_json_home_path())
-    )
+          )
 
     _login(email, password)
 
@@ -119,7 +119,8 @@ def login(args=None):
     password = get_input("Password: ", True)
     success, default_api_key = _login(email, password)
     if success:
-        print("Successfully logged in! We also installed: {} as your default API key".format(default_api_key))
+        print("Successfully logged in! We also installed: {} as your default API key".format(
+            default_api_key))
 
 
 def _login(email, password):
@@ -145,7 +146,7 @@ def _login(email, password):
     # Add API key if available
     api_keys = get_api_keys(access_token)
     if api_keys and len(api_keys) > 0:
-        default_api_key = api_keys[0]    
+        default_api_key = api_keys[0]
         config['api_key'] = default_api_key
     else:
         print("Login failure: We were unable to retrieve your default API key.")
@@ -190,7 +191,7 @@ def keys(args=None):
     print("\nBelow are the API Keys associated with you account:\n\n")
 
     for i, api_key in enumerate(api_keys):
-        print("    {}) {}".format(i+1, api_key))
+        print("    {}) {}".format(i + 1, api_key))
 
     print("\n")
 
@@ -199,10 +200,10 @@ def run(args):
     @monitor(args.name)
     def wrapped():
         # Python detects when its connected to a pipe and buffers output.
-        # Spawn the users program with the PYTHONUNBUFFERED environment 
+        # Spawn the users program with the PYTHONUNBUFFERED environment
         # variable set in case they are running a Python program.
         subprocess_env = os.environ.copy()
-        subprocess_env["PYTHONUNBUFFERED"]="1"
+        subprocess_env["PYTHONUNBUFFERED"] = "1"
         # Spawn a subprocess with the user's command
         p = subprocess.Popen(
             ' '.join(args.args),
@@ -220,7 +221,7 @@ def run(args):
         # the monitor decorator)
         def stdout_loop():
             while True:
-                data = p.stdout.readline()
+                data = p.stdout.read(1)
                 if not data:
                     return
                 # In PY2 data is str, in PY3 its bytes
@@ -228,16 +229,17 @@ def run(args):
                     sys.stdout.write(data)
                     continue
                 sys.stdout.write(data.decode("utf-8", "ignore"))
+
         def stderr_loop():
             while True:
-                data = p.stderr.readline()
+                data = p.stderr.read(1)
                 if not data:
                     return
                 # In PY2 data is str, in PY3 its bytes
                 if PY2:
-                    sys.stdout.write(data)
+                    sys.stderr.write(data)
                     continue
-                sys.stdout.write(data.decode("utf-8", "ignore"))
+                sys.stderr.write(data.decode("utf-8", "ignore"))
 
         stdout_thread = Thread(target=stdout_loop)
         stderr_thread = Thread(target=stderr_loop)
@@ -259,6 +261,7 @@ def get_input(prompt, sensitive=False):
 
 def get_json(path, **kwargs):
     return requests.get("{}{}".format(get_base_url(), path), **kwargs)
+
 
 def post_json(path, data):
     return requests.post(
@@ -294,7 +297,8 @@ def write_hyperdash_json_helper(file, hyperdash_json):
         try:
             existing = json.loads(data)
         except ValueError:
-            raise Exception("{} is not valid JSON!".format(get_hyperdash_json_home_path()))
+            raise Exception("{} is not valid JSON!".format(
+                get_hyperdash_json_home_path()))
 
     existing.update(hyperdash_json)
 

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -255,20 +255,24 @@ def run(args):
         # stdout/stderr respectively (which have been redirected by
         # the monitor decorator)
         def stdout_loop():
-            for data in generate_tokens(p.stdout):
+            # for data in generate_tokens(p.stdout):
+            while True:
+                data = p.stdout.read(1)
+                if not data:
+                    return
                 # In PY2 data is str, in PY3 its bytes
                 if PY2:
                     sys.stdout.write(data)
-                    continue
-                sys.stdout.write(data.decode("utf-8", "ignore"))
+                else:
+                    sys.stdout.write(data.decode("utf-8", "ignore"))
 
         def stderr_loop():
             for data in generate_tokens(p.stderr):
                 # In PY2 data is str, in PY3 its bytes
                 if PY2:
                     sys.stderr.write(data)
-                    continue
-                sys.stderr.write(data.decode("utf-8", "ignore"))
+                else:
+                    sys.stderr.write(data.decode("utf-8", "ignore"))
 
         stdout_thread = Thread(target=stdout_loop)
         stderr_thread = Thread(target=stderr_loop)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.7.4"
+version = "0.7.5"
 
 setup(
     name='hyperdash',


### PR DESCRIPTION
This PR modifies the code hyperdash run command to read one character at a time off the pipes instead of one line at a time, and output them everytime a whitespace is encountered. This makes it so that progress bars can render in realtime-ish (it wont be as realtime as doing it without the hyperdash run command due to additional buffering).

It also decouples capturing IO locally and capturing IO for the server so that even in situations where many flushes are happening, the server doesn't receive more than 1 message per second.

Closes #63 