### PR TITLE
bugfix for when 'hyperdash' is used from shell on python>=3.3 without…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env/
 build/
 dist/
 hyperdash.egg-info/
+.idea/

--- a/hyperdash_cli/cli.py
+++ b/hyperdash_cli/cli.py
@@ -383,7 +383,9 @@ def main():
         title='subcommands',
         description='valid subcommands',
         help='additional help',
+        dest='subcommand'
     )
+    subparsers.required = True
 
     signup_parser = subparsers.add_parser('signup')
     signup_parser.set_defaults(func=signup)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.7.8"
+version = "0.7.9"
 
 setup(
     name='hyperdash',


### PR DESCRIPTION
Since Python 3.3 the subparsers are optional by default. Therefore if you use `hyperdash` on the shell without any parameters under Python>=3.3, you get a nasty exception.

This is a known problem with Python. Solution was taken from here:
https://bugs.python.org/issue9253
