### PR TITLE
Improve Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ hd run -n "Hotdog CNN" python hotdog.py
 ```
 Or use pipe:
 ```bash
-./catsdogs.sh | hd pipe
+./catsdogs.sh | hd pipe -n "Hotdog CNN"
 ```
 In Jupyter:
 


### PR DESCRIPTION
I got

```
esc@phoebe:~/baseline$ CUDA_VISIBLE_DEVICES=0,1,2,3 python train.py -c configs/config_model1.json -g 0,1,2,3 | hd pipe
usage: hd pipe [-h] --name NAME
hd pipe: error: the following arguments are required: --name/-name/--n/-n
```

Updating the documentation should stop others from hitting this snag.