### PR TITLE
Add tensorboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ def train_dogs_vs_cats(exp): # Get Experiment object as argument to function.
   model.fit()
   exp.metric(model.accuracy())
 ```
+
+## Tensorboard auto-instrumentation.
+If you use Tensorboard for monitoring, Hyperdash can monitor the same `tfevents` files. Simply point the Hyperdash SDK to your log directory. For example if you start tensorboard in Terminal like this:
+```bash
+tensorboard --logdir=/tmp/tensorflow_logs
+```
+You would run in a seperate terminal tab:
+```bash
+hd tensorboard -n ModelNameHere --logdir=/tmp/tensorflow_logs
+```
+Then Hyperdash will automatically categorize all future tensorflow runs in the same directory under the same model name. You'll even get push notifications and real-time metrics!
+
 ## API Keys
 ### Storage
 


### PR DESCRIPTION
Added basic docs. LMK what you think @richardartoul 

When testing with https://github.com/aymericdamien/TensorFlow-Examples/blob/master/examples/4_Utils/tensorboard_basic.py, I ran into a few issues.

1) SDK watcher never detects that tensorflow experiment ended - it goes on forever.

2) Ending the sdk watcher causes the run to complete. (I guess this is hard to avoid) 

3) However when you start the sdk watcher again, it creates a new forever run (even though a new experiment hasn't been created)